### PR TITLE
14.0

### DIFF
--- a/l10n_tw_standard_ifrss/__init__.py
+++ b/l10n_tw_standard_ifrss/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-
+# License LGPL-3.0
 # Copyright (C) 2017-now  元植管理顧問chingyun@yuanchih-consult.com

--- a/l10n_tw_standard_ifrss/__init__.py
+++ b/l10n_tw_standard_ifrss/__init__.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-# Copyright (C) 2008-2008 凯源吕鑫 lvxin@gmail.com   <basic chart data>
-#                         维智众源 oldrev@gmail.com  <states data>
-# Copyright (C) 2012-2012 南京盈通 ccdos@intoerp.com <small business chart>
-# Copyright (C) 2008-now  开阖软件 jeff@osbzr.com    < PM and LTS >
-# Copyright (C) 2017-now  jeffery9@gmail.com
+
 # Copyright (C) 2017-now  元植管理顧問chingyun@yuanchih-consult.com

--- a/l10n_tw_standard_ifrss/__manifest__.py
+++ b/l10n_tw_standard_ifrss/__manifest__.py
@@ -49,7 +49,7 @@ Including the following data in the Accounting Standards for Business Enterprise
 
 ★社群支持：工具人
 
-★技術支援：先捷電腦
+★技術支援：先傑電腦
 
 
 

--- a/l10n_tw_standard_ifrss/data/account.account.template.csv
+++ b/l10n_tw_standard_ifrss/data/account.account.template.csv
@@ -967,7 +967,7 @@ account_832300,832300,採用權益法認列關聯企業及合資之指定損益�
 account_832400,832400,採用權益法認列關聯企業及合資之與待出售非流動資產直接相關之權益,FALSE,l10n_tw_standard_ifrss.account_type_other_comprehensive,l10n_chart_taiwan_standard_business
 account_832500,832500,採用權益法認列關聯企業及合資之與與待分配予業主之非流動資產(或處分群組)直接相關之權益,FALSE,l10n_tw_standard_ifrss.account_type_other_comprehensive,l10n_chart_taiwan_standard_business
 account_832600,832600,採用權益法認列關聯企業及合資之透過其他綜合損益按公允價值衡量權益工具未實現評價損益,FALSE,l10n_tw_standard_ifrss.account_type_other_comprehensive,l10n_chart_taiwan_standard_business
-account_831700,831700,採用權益法認列關聯企業及合資之避險工具之損益,FALSE,l10n_tw_standard_ifrss.account_type_other_comprehensive,l10n_chart_taiwan_standard_business
+account_832700,832700,採用權益法認列關聯企業及合資之避險工具之損益,FALSE,l10n_tw_standard_ifrss.account_type_other_comprehensive,l10n_chart_taiwan_standard_business
 account_833000,833000,採用權益法認列之子公司、關聯企業及合資之其他綜合損益之份額-不重分類至損益之項目,FALSE,l10n_tw_standard_ifrss.account_type_other_comprehensive,l10n_chart_taiwan_standard_business
 account_833100,833100,採用權益法認列子公司、關聯企業及合資之確定福利計畫再衡量數,FALSE,l10n_tw_standard_ifrss.account_type_other_comprehensive,l10n_chart_taiwan_standard_business
 account_833200,833200,採用權益法認列子公司、關聯企業及合資之不動產重估增值,FALSE,l10n_tw_standard_ifrss.account_type_other_comprehensive,l10n_chart_taiwan_standard_business

--- a/l10n_tw_standard_ifrss/data/account.financial.report.xml
+++ b/l10n_tw_standard_ifrss/data/account.financial.report.xml
@@ -110,6 +110,7 @@
         </record>
         <record id="account.account_financial_report_42" model="account.financial.report">
             <field name="parent_id" ref="account.account_financial_report_41" />
+            <field name="account_report_id" ref="account.e_equity" />
         </record>
         <record id="account.account_financial_report_43" model="account.financial.report">
             <field name="parent_id" ref="account.account_financial_report_41" />


### PR DESCRIPTION
本模塊於14版進行功能任務調整，調整後提供以下功能：
*1.台灣常用會計項目匯入
*2.依odoo社區版財務報表模組(accounting_pdf_reports)為報表基礎呈現之台灣使用習慣財務報表結構

相關社區版財務報表運作方式、元植財務報表邏輯結構與年度結轉方式請詳以下文章：
https://www.yuanchih-consult.com/blog/odoo-1/post/odooodoo-15

odoo社區版系統上線前之基礎知識-odoo應用雲端課程說明：
https://www.yuanchih-consult.com/page/onlineclass

*本模組之使用請先下載並安裝l10n_tw模組
https://github.com/Odoo-Taiwan/l10n_tw




*特別感謝：
★技術支援：新北工具人
★技術支援：先傑電腦
★技術支援：odooTaiwan曾大大